### PR TITLE
feat: Add Viem exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,53 @@ Access the Universal Sign-In authentication state and user information.
 
 - Core wallet functionality from `@dynamic-labs/global-wallet-client/features`
 - Key Ethereum utilities from `@dynamic-labs/ethereum` (connectors, helpers, etc.)
+
+**From `@zetachain/wallet/ethers`:**
+
 - Ethers.js integration from `@dynamic-labs/ethers-v6`
+
+**From `@zetachain/wallet/viem`:**
+
+- Viem integration utilities including `getViemWalletClient()` function
 
 This means you never need to install Dynamic SDK packages directly.
 
 For authentication state and user information, use `useUniversalSignInContext`.
+
+## Viem Integration
+
+For applications using Viem, you can access wallet functionality through the dedicated Viem exports:
+
+```tsx
+import { getViemWalletClient } from "@zetachain/wallet/viem";
+import { useUniversalSignInContext } from "@zetachain/wallet/react";
+import { parseEther } from "viem";
+
+function SendTransaction() {
+  const { primaryWallet } = useUniversalSignInContext();
+
+  const handleSend = async () => {
+    if (!primaryWallet) return;
+
+    const walletClient = getViemWalletClient(primaryWallet);
+
+    const hash = await walletClient.sendTransaction({
+      to: "0x...",
+      value: parseEther("1.0"),
+    });
+
+    console.log("Transaction hash:", hash);
+  };
+
+  return <button onClick={handleSend}>Send Transaction</button>;
+}
+```
+
+**Available Viem exports:**
+
+- `getViemWalletClient(primaryWallet)`: Extracts a Viem WalletClient from a Primary Wallet instance
+- `PrimaryWallet`: Type for the base primary wallet
+- `PrimaryWalletWithViemWalletClient`: Type for primary wallet with Viem support
 
 ## Environment Configuration
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
       ],
       "ethers": [
         "./dist/types/ethers.d.ts"
+      ],
+      "viem": [
+        "./dist/types/viem.d.ts"
       ]
     }
   },
@@ -133,6 +136,11 @@
       "types": "./dist/types/ethers.d.ts",
       "import": "./dist/esm/ethers.js",
       "default": "./dist/cjs/ethers.js"
+    },
+    "./viem": {
+      "types": "./dist/types/viem.d.ts",
+      "import": "./dist/esm/viem.js",
+      "default": "./dist/cjs/viem.js"
     }
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from "@dynamic-labs/global-wallet-client/features";
 
 // Export constants and types
 export { DYNAMIC_ENVIRONMENT_IDS, type DynamicEnvironment } from "./constants";
+export type { PrimaryWallet } from "./types";
 
 // Export key ethereum utilities (excluding isEthereumWallet due to conflict with global-wallet-client)
 export {

--- a/src/lib/viemClient.ts
+++ b/src/lib/viemClient.ts
@@ -1,0 +1,34 @@
+import { PrimaryWallet, PrimaryWalletWithViemWalletClient } from "../types";
+
+/**
+ * Extracts a Viem WalletClient from a Primary Wallet instance.
+ *
+ * @param primaryWallet - The primary wallet instance from useUniversalSignInContext
+ * @returns The Viem WalletClient for interacting with the wallet
+ * @throws {Error} When primaryWallet is null/undefined or doesn't support Viem
+ *
+ * @example
+ * ```typescript
+ * import { getViemWalletClient } from '@zetachain/wallet/viem';
+ *
+ * const { primaryWallet } = useUniversalSignInContext();
+ * const walletClient = getViemWalletClient(primaryWallet);
+ *
+ * // Use with Viem actions
+ * const hash = await walletClient.sendTransaction({
+ *   to: '0x...',
+ *   value: parseEther('1.0')
+ * });
+ * ```
+ */
+export const getViemWalletClient = async (primaryWallet: PrimaryWallet) => {
+  if (!primaryWallet) {
+    throw new Error("Invalid Primary Wallet");
+  }
+
+  const walletClient = await (
+    primaryWallet as PrimaryWalletWithViemWalletClient
+  ).getWalletClient();
+
+  return walletClient;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export type { PrimaryWalletWithViemWalletClient } from "./viem";
+export type { PrimaryWallet } from "./wallet";

--- a/src/types/viem.ts
+++ b/src/types/viem.ts
@@ -1,0 +1,7 @@
+import { WalletClient } from "viem";
+
+import { PrimaryWallet } from "./wallet";
+
+export type PrimaryWalletWithViemWalletClient = PrimaryWallet & {
+  getWalletClient(chainId?: string): Promise<WalletClient>;
+};

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -1,0 +1,5 @@
+import { useUniversalSignInContext } from "../react";
+
+export type PrimaryWallet = ReturnType<
+  typeof useUniversalSignInContext
+>["primaryWallet"];

--- a/src/viem.ts
+++ b/src/viem.ts
@@ -1,0 +1,2 @@
+export { getViemWalletClient as getWalletClient } from "./lib/viemClient";
+export type { PrimaryWalletWithViemWalletClient } from "./types/viem";


### PR DESCRIPTION
## Summary

  - Add Viem integration support through dedicated `@zetachain/wallet/viem` subpath export.
  - Implement `getViemWalletClient()` function to extract Viem `WalletClient` from Primary Wallet.
  - Add TypeScript types for Viem wallet integration (`PrimaryWallet`, `PrimaryWalletWithViemWalletClient`)
  - Update package.json exports to support `./viem` subpath with proper ESM/CJS/types mapping
  - Add comprehensive Viem usage documentation and examples to `README`
