### PR TITLE
chore: Add preferred chain default

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The main provider component that configures Dynamic SDK for ZetaChain's Universa
 
 - `settings`: Dynamic SDK configuration object with the following structure:
   - `cssOverrides`: Custom CSS styles (built-in overrides are applied after user styles for consistent UX)
+  - `walletConnectPreferredChains`: Array of preferred chain IDs for WalletConnect (defaults to `["eip155:7000"]`)
   - `overrides`: Dynamic SDK override settings
   - All other standard Dynamic SDK settings (appName, appLogoUrl, etc.)
 

--- a/src/react/providers/UniversalSignInContextProvider.tsx
+++ b/src/react/providers/UniversalSignInContextProvider.tsx
@@ -69,6 +69,11 @@ export const UniversalSignInContextProvider: React.FC<
     // Set the environment ID based on the environment prop
     environmentId,
 
+    // Provide default walletConnectPreferredChains if not set in user settings
+    walletConnectPreferredChains: settings.walletConnectPreferredChains || [
+      "eip155:7000",
+    ],
+
     walletConnectors: [EthereumWalletConnectors],
   };
 


### PR DESCRIPTION
## Description

Sets `walletConnectPreferredChains` to default to ZetaChain (["eip155:7000"]) when not specified.